### PR TITLE
Changing methods to take &str instead of String

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -12,16 +12,16 @@ use std::thread;
 
 fn main() {
     let mut metrics_controller = MetricsController::new(
-        "foxbox".to_string(),
-        "1.0".to_string(),
-        "default".to_string(),
-        "20160305".to_string(),
-        "rust".to_string(),
-        "en-us".to_string(),
-        "raspberry-pi".to_string(),
-        "arm".to_string(),
-        "linux".to_string(),
-        "1.2.3.".to_string());
+        "foxbox",
+        "1.0",
+        "default",
+        "20160305",
+        "rust",
+        "en-us",
+        "raspberry-pi",
+        "arm",
+        "linux",
+        "1.2.3.");
 
     metrics_controller.record_event("event category",
                                     "event action",

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,8 +11,8 @@ use std::path::Path;
 use std::collections::BTreeMap;
 
 
-//This is the config file that reads all the json from metricsconfig.json.  We can initially use
-//an environment variable to locate this file or can be passed in.
+// This is the config file that reads all the json from metricsconfig.json.  We can initially use
+// an environment variable to locate this file or can be passed in.
 // The worker thread and the app thread will both read from this file.
 
 #[allow(non_upper_case_globals)]
@@ -23,35 +23,35 @@ pub struct Config {
 }
 
 impl Config {
-
     pub fn new() -> Config {
-        Config{
-            parsed_json: None,
-        }
+        Config { parsed_json: None }
     }
 
     #[cfg(not(test))]
-    pub fn create_and_write_json(&mut self, file_name: &str, json: &str)  {
-        logger().log(LogLevelFilter::Debug, format!("file: {}", file_name).as_str());
+    pub fn create_and_write_json(&mut self, file_name: &str, json: &str) {
+        logger().log(LogLevelFilter::Debug,
+                     format!("file: {}", file_name).as_str());
         let f = File::create(file_name);
         match f {
             Ok(mut t) => {
                 let _ = t.write(json.as_bytes());
-            },
+            }
             Err(e) => panic!("cannot open file: {}", e),
         };
     }
 
     pub fn init(&mut self, file_name: &str) -> bool {
-        //TODO:  Need to make this look at env variable or take a path to the file.
-        logger().log(LogLevelFilter::Debug, format!("config file: {}", file_name).as_str());
+        // TODO:  Need to make this look at env variable or take a path to the file.
+        logger().log(LogLevelFilter::Debug,
+                     format!("config file: {}", file_name).as_str());
         let path = Path::new(file_name);
         let display = path.display();
         // Open the path in read-only mode.
         let mut file = match File::open(&path) {
             Err(why) => {
-                logger().log(LogLevelFilter::Error, format!("couldn't open {}: {}", display,
-                                                       Error::description(&why)).as_str());
+                logger().log(LogLevelFilter::Error,
+                             format!("couldn't open {}: {}", display, Error::description(&why))
+                                 .as_str());
                 return false;
             }
             Ok(file) => file,
@@ -64,8 +64,10 @@ impl Config {
                 logger().log(LogLevelFilter::Error, format!("Error: {}", why).as_str());
                 return false;
             }
-            Ok(_) => logger().log(LogLevelFilter::Debug,
-                format!("file contains: {}", s).as_str()),
+            Ok(_) => {
+                logger().log(LogLevelFilter::Debug,
+                             format!("file contains: {}", s).as_str())
+            }
         }
         self.parse_json(s);
         true
@@ -95,10 +97,12 @@ impl Config {
         if let Some(ref mut parsed_json) = self.parsed_json {
             let val: Option<Value> = Some(parsed_json.get(key).unwrap().clone());
             match val {
-                Some(v) => match v {
-                    Value::String(v) => v.clone(),
-                    _ => panic!("Expected a String Value"),
-                },
+                Some(v) => {
+                    match v {
+                        Value::String(v) => v.clone(),
+                        _ => panic!("Expected a String Value"),
+                    }
+                }
                 None => panic!("Value not found"),
             }
         } else {
@@ -110,10 +114,12 @@ impl Config {
         if let Some(ref mut parsed_json) = self.parsed_json {
             let val: Option<Value> = Some(parsed_json.get(key).unwrap().clone());
             match val {
-                Some(v) => match v {
-                    Value::U64(v) => return v,
-                    _ => panic!("Expected a u64"),
-                },
+                Some(v) => {
+                    match v {
+                        Value::U64(v) => return v,
+                        _ => panic!("Expected a u64"),
+                    }
+                }
                 None => panic!("Value not found"),
             }
         } else {
@@ -148,9 +154,11 @@ describe! parsing_file {
         #[allow(unused_imports)]
         use config::serde_json::Value;
 
-        let s: String = "{\"sendInterval\": 10, \"saveInterval\": 2, \
-        	\"startTime\": 0, \"savePath\": \"testSavePath\", \
-        	\"logPath\": \"/Volumes/development/metrics_controller/log\"}".to_string();
+        let s = r#"{ "sendInterval": 10,
+                     "saveInterval": 2,
+        	         "startTime": 0,
+                     "savePath": "testSavePath",
+        	         "logPath": "/Volumes/development/metrics_controller/log" }"#.to_string();
         let mut cfg = Config::new();
         cfg.parse_json(s);
     }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -19,26 +19,33 @@ pub struct EventInfo {
     pub app_version: String,
     pub app_update_channel: String,
     pub app_build_id: String,
-    pub app_platform: String
+    pub app_platform: String,
 }
 
 impl EventInfo {
-    pub fn new(locale: String, os: String, os_version: String, device: String, app_name: String,
-               app_version: String, app_update_channel: String,
-               app_build_id: String, app_platform: String,
-               arch: String) -> EventInfo {
+    pub fn new(locale: &str,
+               os: &str,
+               os_version: &str,
+               device: &str,
+               app_name: &str,
+               app_version: &str,
+               app_update_channel: &str,
+               app_build_id: &str,
+               app_platform: &str,
+               arch: &str)
+               -> EventInfo {
 
         EventInfo {
-            locale: locale,
-            os: os,
-            os_version: os_version,
-            device: device,
-            app_name: app_name,
-            app_version: app_version,
-            app_update_channel: app_update_channel,
-            app_build_id: app_build_id,
-            app_platform: app_platform,
-            arch: arch
+            locale: locale.to_owned(),
+            os: os.to_owned(),
+            os_version: os_version.to_owned(),
+            device: device.to_owned(),
+            app_name: app_name.to_owned(),
+            app_version: app_version.to_owned(),
+            app_update_channel: app_update_channel.to_owned(),
+            app_build_id: app_build_id.to_owned(),
+            app_platform: app_platform.to_owned(),
+            arch: arch.to_owned(),
         }
     }
 }
@@ -46,11 +53,10 @@ impl EventInfo {
 /// The metrics controller for the CD Metrics Library
 pub struct MetricsController {
     events: Arc<Mutex<Events>>,
-    mw: MetricsWorker
+    mw: MetricsWorker,
 }
 
 impl MetricsController {
-
     //  Note: The following code example produces an 'unused variable' warning
     //        so it is being ignored for the purpose of running tests.
 
@@ -74,27 +80,33 @@ impl MetricsController {
     ///     "linux".to_string(),
     ///     "1.2.3".to_string());
     /// ```
-    pub fn new(app_name: String, app_version: String,
-               app_update_channel: String, app_build_id: String,
-               app_platform: String, locale: String,
-               device: String, arch: String, os: String, os_version: String) -> MetricsController {
+    pub fn new(app_name: &str,
+               app_version: &str,
+               app_update_channel: &str,
+               app_build_id: &str,
+               app_platform: &str,
+               locale: &str,
+               device: &str,
+               arch: &str,
+               os: &str,
+               os_version: &str)
+               -> MetricsController {
         logger().log(LogLevelFilter::Info, "Creating Controller");
-        let event_info = EventInfo::new(
-                    locale,
-                    os,
-                    os_version,
-                    device,
-                    app_name,
-                    app_version,
-                    app_update_channel,
-                    app_build_id,
-                    app_platform,
-                    arch);
+        let event_info = EventInfo::new(locale,
+                                        os,
+                                        os_version,
+                                        device,
+                                        app_name,
+                                        app_version,
+                                        app_update_channel,
+                                        app_build_id,
+                                        app_platform,
+                                        arch);
         let events = Arc::new(Mutex::new(Events::new(event_info)));
 
         MetricsController {
             events: events.clone(),
-            mw: MetricsWorker::new(events)
+            mw: MetricsWorker::new(events),
         }
     }
 
@@ -105,15 +117,15 @@ impl MetricsController {
     /// transmitting it to the telemetry server.
     pub fn start_metrics(&mut self) -> bool {
 
-        //Data needs to be read from disk here.  Let's assume that the controller
-        //owns the histogram data for now.
+        // Data needs to be read from disk here.  Let's assume that the controller
+        // owns the histogram data for now.
         // Needs to call persistence module to read the data file.
         // Call config.init()
         // Call persistence.read() and populate histograms in memory in controller.
         // histograms in separate structs in separate files.  Controller maintains
         // a refernce to the in memory histograms.  Worker thread also needs it.
         // We would prefer to use a singleton pattern.
-        //MetricsWorker::new();
+        // MetricsWorker::new();
         true
     }
 
@@ -148,7 +160,8 @@ impl MetricsController {
                         event_category: &str,
                         event_action: &str,
                         event_label: &str,
-                        event_value: u64) -> bool {
+                        event_value: u64)
+                        -> bool {
         let mut events = self.events.lock().unwrap();
         events.insert_event(event_category, event_action, event_label, event_value)
     }
@@ -156,22 +169,22 @@ impl MetricsController {
 
 // Create a MetricsController with predefined values
 // for unit testing.
-/*
- * TODO This function is commented out because it is not being used.
- *      Uncomment when there are unit tests that need it.
-#[cfg(test)]
-fn create_metrics_controller() -> MetricsController {
-    MetricsController::new(
-        "app".to_string(),
-        "1.0".to_string(),
-        "default".to_string(),
-        "20160305".to_string(),
-        "rust".to_string(),
-        "en-us".to_string(),
-        "linux".to_string(),
-        "1.2.3".to_string(),
-        "raspberry-pi".to_string(),
-        "arm".to_string()
-    )
-}
-*/
+//
+// TODO This function is commented out because it is not being used.
+//      Uncomment when there are unit tests that need it.
+// #[cfg(test)]
+// fn create_metrics_controller() -> MetricsController {
+// MetricsController::new(
+// "app",
+// "1.0",
+// "default",
+// "20160305",
+// "rust",
+// "en-us",
+// "linux",
+// "1.2.3",
+// "raspberry-pi",
+// "arm"
+// )
+// }
+//

--- a/src/events.rs
+++ b/src/events.rs
@@ -24,7 +24,7 @@ const logger: fn() -> &'static MetricsLogger = MetricsLoggerFactory::get_logger;
 
 const MAX_EVENT_SIZE: usize = 20;
 #[cfg(not(test))]
-const KEY_CID:&'static str = "cid";
+const KEY_CID: &'static str = "cid";
 
 define_encode_set! {
     /// This encode set is used in the URL parser for query strings.
@@ -34,7 +34,7 @@ define_encode_set! {
 pub struct Events {
     event_storage: VecDeque<String>,
     event_info: EventInfo,
-    client_id: String
+    client_id: String,
 }
 
 impl Events {
@@ -42,30 +42,35 @@ impl Events {
         Events {
             event_storage: VecDeque::with_capacity(20),
             event_info: event_info,
-            client_id: get_client_id()
+            client_id: get_client_id(),
         }
     }
 
-    pub fn insert_event(&mut self, event_category: &str, event_action: &str, event_label: &str, event_value: u64) -> bool  {
+    pub fn insert_event(&mut self,
+                        event_category: &str,
+                        event_action: &str,
+                        event_label: &str,
+                        event_value: u64)
+                        -> bool {
 
-        let event_string = format!("v=1&t=event&tid=UA-77033033-1&cid={0}&ec={1}&ea={2}&el={3}&ev={4}&an={5}&av={6}&ul={7}\
-                                    &cd1={8}&cd2={9}&cd3={10}&cd4={11}&cd5={12}&cd6={13}&cd7={14}",
-                                    self.encode_value(self.client_id.clone()),
-                                    self.encode_value(event_category.to_string()),
-                                    self.encode_value(event_action.to_string()),
-                                    self.encode_value(event_label.to_string()),
-                                    event_value,
-                                    self.encode_value(self.event_info.app_name.clone()),
-                                    self.encode_value(self.event_info.app_version.clone()),
-                                    self.encode_value(self.event_info.locale.clone()),
-                                    self.encode_value(self.event_info.os.clone()),
-                                    self.encode_value(self.event_info.os_version.clone()),
-                                    self.encode_value(self.event_info.device.clone()),
-                                    self.encode_value(self.event_info.arch.clone()),
-                                    self.encode_value(self.event_info.app_platform.clone()),
-                                    self.encode_value(self.event_info.app_build_id.clone()),
-                                    self.encode_value(get_time_string()));
-        logger().log(LogLevelFilter::Debug, format!("Inserted event: {}", event_string).as_str());
+        let event_string = format!("v=1&t=event&tid=UA-77033033-1&cid={0}&ec={1}&ea={2}&el={3}&ev={4}&an={5}&av={6}&ul={7}&cd1={8}&cd2={9}&cd3={10}&cd4={11}&cd5={12}&cd6={13}&cd7={14}",
+                                   self.encode_value(self.client_id.clone()),
+                                   self.encode_value(event_category.to_string()),
+                                   self.encode_value(event_action.to_string()),
+                                   self.encode_value(event_label.to_string()),
+                                   event_value,
+                                   self.encode_value(self.event_info.app_name.clone()),
+                                   self.encode_value(self.event_info.app_version.clone()),
+                                   self.encode_value(self.event_info.locale.clone()),
+                                   self.encode_value(self.event_info.os.clone()),
+                                   self.encode_value(self.event_info.os_version.clone()),
+                                   self.encode_value(self.event_info.device.clone()),
+                                   self.encode_value(self.event_info.arch.clone()),
+                                   self.encode_value(self.event_info.app_platform.clone()),
+                                   self.encode_value(self.event_info.app_build_id.clone()),
+                                   self.encode_value(get_time_string()));
+        logger().log(LogLevelFilter::Debug,
+                     format!("Inserted event: {}", event_string).as_str());
         self.event_storage.push_back(event_string);
 
         true
@@ -76,7 +81,7 @@ impl Events {
         let value_vec = value.into_bytes();
         let mut bs = percent_encoding::percent_encode(&value_vec, GOOGLE_ENCODE_SET);
 
-        loop  {
+        loop {
             match bs.next() {
                 Some(bs) => {
                     value_encoded.push_str(bs);
@@ -90,11 +95,7 @@ impl Events {
     }
 
     pub fn is_time_to_send(&mut self) -> bool {
-        if self.event_storage.len() >= MAX_EVENT_SIZE {
-            true
-        } else {
-            false
-        }
+        self.event_storage.len() >= MAX_EVENT_SIZE
     }
 
     pub fn is_empty(&mut self) -> bool {
@@ -103,17 +104,17 @@ impl Events {
 
     pub fn get_events_as_body(&mut self) -> String {
         let mut body = String::new();
-        let mut i:usize = 0;
+        let mut i: usize = 0;
         while i < MAX_EVENT_SIZE {
             let val: Option<String> = self.event_storage.pop_front();
             match val {
                 Some(v) => {
                     body.push_str(&v);
                     body.push_str("\n");
-                },
+                }
                 None => {
                     break;
-                },
+                }
             }
             i = i + 1;
         }
@@ -129,7 +130,7 @@ fn get_client_id() -> String {
         let val: Option<Value> = cfg.get(KEY_CID);
         match val {
             Some(_) => cid.push_str(&cfg.get_string(KEY_CID).to_string()),
-            None => panic!("Error: no cid written")
+            None => panic!("Error: no cid written"),
         }
     } else {
         cid.push_str(&Uuid::new_v4().to_hyphenated_string().to_string());
@@ -148,8 +149,13 @@ fn get_client_id() -> String {
 #[cfg(not(test))]
 fn get_time_string() -> String {
     let ts = time::now_utc();
-    let time_string = format!("{0:4}-{1:02}-{2:02} {3:02}:{4:02}:{5:02}", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday,
-                                                                          ts.tm_hour, ts.tm_min, ts.tm_sec);
+    let time_string = format!("{0:4}-{1:02}-{2:02} {3:02}:{4:02}:{5:02}",
+                              ts.tm_year + 1900,
+                              ts.tm_mon + 1,
+                              ts.tm_mday,
+                              ts.tm_hour,
+                              ts.tm_min,
+                              ts.tm_sec);
     time_string
 }
 
@@ -165,16 +171,16 @@ describe! events_functionality {
         use controller::EventInfo;
 
         let event_info = EventInfo::new(
-                    "en-us".to_string(),
-                    "linux".to_string(),
-                    "1.2".to_string(),
-                    "RPi/2".to_string(),
-                    "iot_app".to_string(),
-                    "1.0".to_string(),
-                    "default".to_string(),
-                    "20160320123456".to_string(),
-                    "rust test".to_string(),
-                    "arm".to_string());
+                    "en-us",
+                    "linux",
+                    "1.2",
+                    "RPi/2",
+                    "iot_app",
+                    "1.0",
+                    "default",
+                    "20160320123456",
+                    "rust test",
+                    "arm");
         let mut ev = Events::new(event_info);
         ev.client_id = "9eccb690-93aa-4513-835a-9a4f0f0e2a71".to_string();
     }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -40,9 +40,7 @@ impl MetricsLogger {
     // information see:
     // http://rust-lang-nursery.github.io/log/env_logger/struct.LogBuilder.html
     pub fn init(&self) {
-        let format = |record: &LogRecord| {
-            format!("{} - {}", record.level(), record.args())
-        };
+        let format = |record: &LogRecord| format!("{} - {}", record.level(), record.args());
 
         let mut builder = LogBuilder::new();
 
@@ -63,7 +61,7 @@ impl MetricsLogger {
             LogLevelFilter::Info => info!("{} - {}", LOG_PREFIX, msg),
             LogLevelFilter::Debug => debug!("{} - {}", LOG_PREFIX, msg),
             LogLevelFilter::Error => error!("{} - {}", LOG_PREFIX, msg),
-            _ => println!("{} is not a supported log level", level)
+            _ => println!("{} is not a supported log level", level),
         }
     }
 }

--- a/src/metrics_worker.rs
+++ b/src/metrics_worker.rs
@@ -20,22 +20,22 @@ use transmitter::Transmitter;
 #[allow(non_upper_case_globals)]
 const logger: fn() -> &'static MetricsLogger = MetricsLoggerFactory::get_logger;
 
-const DEFAULT_SEND:u64 = 1209600;
-const DEFAULT_SAVE:u64 = 3600;
-const DEFAULT_START:u64 = 0;
-const KEY_START:&'static str = "startTime";
-const KEY_SAVE:&'static str = "saveInterval";
-const KEY_SEND:&'static str = "sendInterval";
+const DEFAULT_SEND: u64 = 1209600;
+const DEFAULT_SAVE: u64 = 3600;
+const DEFAULT_START: u64 = 0;
+const KEY_START: &'static str = "startTime";
+const KEY_SAVE: &'static str = "saveInterval";
+const KEY_SEND: &'static str = "sendInterval";
 
 pub enum TimerOp {
     Send,
     Save,
-    None
+    None,
 }
 
 pub enum ThreadMsg {
     Quit,
-    Continue
+    Continue,
 }
 
 #[derive(Copy, Clone)]
@@ -47,7 +47,7 @@ pub struct MetricsTimer {
 
 impl MetricsTimer {
     pub fn new() -> MetricsTimer {
-        MetricsTimer{
+        MetricsTimer {
             send_interval: DEFAULT_SEND,
             save_interval: DEFAULT_SAVE,
             start_time: DEFAULT_START,
@@ -66,7 +66,7 @@ impl MetricsTimer {
             Some(_) => self.start_time = cfg.get_u64(KEY_START),
             None => {
                 self.start_time = 0;
-            },
+            }
         }
         if self.save_interval >= self.send_interval {
             panic!("Fatal error.  Sending interval < Saving Interval")
@@ -78,11 +78,11 @@ impl MetricsTimer {
         // This is the first time this device is starting up (ever)
         if self.start_time == 0 {
             self.start_time = now.sec as u64;
-            //TODO:  Write self.start_time in a separate file!!!
+            // TODO:  Write self.start_time in a separate file!!!
             return self.save_interval as i64;
         } else {
-            //Calculate the next interval.. either remaining time til send or
-            //time til save.
+            // Calculate the next interval.. either remaining time til send or
+            // time til save.
             let secs_til_send = now.sec as u64 - self.start_time;
             // If it's time to send in 60 seconds and save interval is 120 secs
             // set the timer for 60 sec.  Otherwise, just set it for save interval.
@@ -100,7 +100,7 @@ impl MetricsTimer {
         if self.start_time == 0 {
             return TimerOp::None;
         } else {
-            //here if it's either time to send or time to save.
+            // here if it's either time to send or time to save.
             if now.sec as u64 - self.start_time >= self.send_interval {
                 self.start_time = 0; // so we know to start a new timer.
                 return TimerOp::Send;
@@ -119,10 +119,9 @@ impl MetricsSender {
     fn new() -> (MetricsSender, Receiver<ThreadMsg>, Sender<ThreadMsg>) {
         let (sender, receiver) = channel();
 
-        let ms = MetricsSender { sender: sender.clone(), };
+        let ms = MetricsSender { sender: sender.clone() };
         (ms, receiver, sender.clone())
     }
-
 }
 
 pub struct MetricsWorker {
@@ -167,15 +166,16 @@ impl MetricsWorker {
                     }
                     let dur: i64 = mt.get_timer_interval();
                     let tx = sender.clone();
-                    let guard = timer.schedule_with_delay(chrono::Duration::seconds(dur), move|| {
-                        tx.send(ThreadMsg::Continue).unwrap();
-                    });
+                    let guard = timer.schedule_with_delay(chrono::Duration::seconds(dur),
+                                                          move || {
+                                                              tx.send(ThreadMsg::Continue).unwrap();
+                                                          });
                     // The guard variable is need to ensure that the timer does not
-                    // go out of scope.  It is a feature of the timer library o make sure that
+                    // go out of scope.  It is a feature of the timer library to make sure that
                     // there are not extra timers lying around.  Then this brings a warning
                     // that guard is not used so the ignore function is essentially a no-op.
                     guard.ignore();
-                    //This is a blocking call
+                    // This is a blocking call
                     let res = receiver.recv();
                     logger().log(LogLevelFilter::Debug, "After recv");
 
@@ -191,10 +191,12 @@ impl MetricsWorker {
                                 }
                             }
                         }
-                        Err(err) => {println!("error: {}", err);}
+                        Err(err) => {
+                            println!("error: {}", err);
+                        }
                     }
                 }
-            }))
+            })),
         }
     }
 
@@ -202,8 +204,6 @@ impl MetricsWorker {
         self.metrics_send.sender.send(ThreadMsg::Quit).unwrap();
     }
 }
-
-
 
 // This is a test struct used for integration tests.  It writes the result of
 // what the thread loop does to a file that is read and validated by the
@@ -213,15 +213,14 @@ struct ThreadTest {
 }
 
 impl ThreadTest {
-    fn new()->ThreadTest {
-        ThreadTest {
-            timer_count:0,
-        }
+    fn new() -> ThreadTest {
+        ThreadTest { timer_count: 0 }
     }
 
     fn increment(&mut self) {
         self.timer_count = self.timer_count + 1;
     }
+
     #[cfg(not(test))]
     fn write(&mut self) {
         use std::fs::File;
@@ -229,27 +228,27 @@ impl ThreadTest {
         use std::io::prelude::*;
 
         match File::create("thread.dat") {
-            Err(why) => panic!("couldn't open:{}",Error::description(&why)),
+            Err(why) => panic!("couldn't open:{}", Error::description(&why)),
             Ok(mut f) => {
                 let write_res = f.write(&[self.timer_count]);
                 match write_res {
                     Ok(count) => {
                         println!("{} bytes written", count);
                     }
-                    Err(e) => panic!("couldn't write: {}", Error::description(&e))
+                    Err(e) => panic!("couldn't write: {}", Error::description(&e)),
                 }
                 match f.sync_all() {
                     Ok(_) => {
                         drop(f);
                     }
-                    Err(e) => panic!("couldn't flush: {}", Error::description(&e))
+                    Err(e) => panic!("couldn't flush: {}", Error::description(&e)),
                 }
             }
         }
     }
 
     #[cfg(test)]
-    fn write(&mut self){
+    fn write(&mut self) {
         logger().log(LogLevelFilter::Debug, "Calling the no-op ThreadTest::write");
     }
 }
@@ -259,7 +258,7 @@ impl ThreadTest {
 #[cfg(test)]
 describe! metrics_timer {
     before_each {
-        // Required to prevent 'unused import' compiler warning
+// Required to prevent 'unused import' compiler warning
         #[allow(unused_imports)]
         use metrics_worker::time::get_time;
         let mut mt = MetricsTimer::new();
@@ -327,18 +326,18 @@ describe! metrics_worker {
         use controller::EventInfo;
         use events::Events;
 
-        let event_info = EventInfo {
-            locale: "en-us".to_string(),
-            os: "linux".to_string(),
-            os_version: "1.2.3.".to_string(),
-            device: "raspberry-pi".to_string(),
-            arch: "rust".to_string(),
-            app_name: "app".to_string(),
-            app_version: "1.0".to_string(),
-            app_update_channel: "default".to_string(),
-            app_build_id: "20160305".to_string(),
-            app_platform: "arm".to_string()
-        };
+        let event_info = EventInfo::new(
+            "en-us",
+            "linux",
+            "1.2.3.",
+            "raspberry-pi",
+            "app",
+            "1.0",
+            "default",
+            "20160305",
+            "arm",
+            "rust"
+        );
         let mut mw = MetricsWorker::new(Arc::new(Mutex::new(Events::new(event_info))));
     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -43,16 +43,16 @@ const KEY_CID:&'static str = "cid";
 #[test]
 fn test_thread_timer() {
     let mut controller = MetricsController::new(
-        "foxbox".to_string(),
-        "1.0".to_string(),
-        "default".to_string(),
-        "20160305".to_string(),
-        "en-us".to_string(),
-        "linux".to_string(),
-        "1.2.3.".to_string(),
-        "raspberry-pi".to_string(),
-        "arm".to_string(),
-        "rust".to_string());
+        "foxbox",
+        "1.0",
+        "default",
+        "20160305",
+        "en-us",
+        "linux",
+        "1.2.3.",
+        "raspberry-pi",
+        "arm",
+        "rust");
 
     controller.start_metrics();
 
@@ -135,9 +135,9 @@ fn test_cid_file_creation_and_proper_reuse() {
     let ei = get_event_info();
 
     let mut metrics_controller = MetricsController::new(
-        ei.app_name.to_string(), ei.app_version.to_string(), ei.app_update_channel.to_string(),
-        ei.app_build_id.to_string(), ei.app_platform.to_string(), ei.locale.to_string(),
-        ei.device.to_string(), ei.arch.to_string(), ei.os.to_string(), ei.os_version.to_string());
+        ei.app_name, ei.app_version, ei.app_update_channel,
+        ei.app_build_id, ei.app_platform, ei.locale,
+        ei.device, ei.arch, ei.os, ei.os_version);
 
     metrics_controller.record_event(event_category, event_action, event_label, event_value);
     let cid1 = read_client_id();
@@ -146,9 +146,9 @@ fn test_cid_file_creation_and_proper_reuse() {
     thread::sleep(std::time::Duration::from_secs(3));
     {
         let mut metrics_controller2 = MetricsController::new(
-            ei.app_name.to_string(), ei.app_version.to_string(), ei.app_update_channel.to_string(),
-            ei.app_build_id.to_string(), ei.app_platform.to_string(), ei.locale.to_string(),
-            ei.device.to_string(), ei.arch.to_string(), ei.os.to_string(), ei.os_version.to_string());
+            ei.app_name, ei.app_version, ei.app_update_channel,
+            ei.app_build_id, ei.app_platform, ei.locale,
+            ei.device, ei.arch, ei.os, ei.os_version);
 
         metrics_controller2.record_event(event_category, event_action, event_label, event_value);
         let cid2 = read_client_id();
@@ -209,9 +209,9 @@ fn test_max_body_size() {
     let ei = get_event_info();
 
     let mut metrics_controller = MetricsController::new(
-        ei.app_name.to_string(), ei.app_version.to_string(), ei.app_update_channel.to_string(),
-        ei.app_build_id.to_string(), ei.app_platform.to_string(), ei.locale.to_string(),
-        ei.device.to_string(), ei.arch.to_string(), ei.os.to_string(), ei.os_version.to_string());
+        ei.app_name, ei.app_version, ei.app_update_channel,
+        ei.app_build_id, ei.app_platform, ei.locale,
+        ei.device, ei.arch, ei.os, ei.os_version);
 
     for _ in 0.. 20 {
         metrics_controller.record_event(event_category, event_action, event_label, event_value);
@@ -262,9 +262,9 @@ fn test_google_analytics_received() {
     let ei = get_event_info();
 
     let mut metrics_controller = MetricsController::new(
-        ei.app_name.to_string(), ei.app_version.to_string(), ei.app_update_channel.to_string(),
-        ei.app_build_id.to_string(), ei.app_platform.to_string(), ei.locale.to_string(),
-        ei.device.to_string(), ei.arch.to_string(), ei.os.to_string(), ei.os_version.to_string());
+        ei.app_name, ei.app_version, ei.app_update_channel,
+        ei.app_build_id, ei.app_platform, ei.locale,
+        ei.device, ei.arch, ei.os, ei.os_version);
 
     // Test with the max payload number of events (20 hits can go in one POST request).
     for _ in 0 .. 20 {


### PR DESCRIPTION
I also ran rustfmt, but the only real changes are to remove the burden of building Strings from the callers.

r? @tamarahills 
